### PR TITLE
Set default log retention

### DIFF
--- a/yggdrasil/services/kafka/config.yaml
+++ b/yggdrasil/services/kafka/config.yaml
@@ -10,6 +10,6 @@ apps:
     replace: true
     source:
       repoURL: "https://distributed-technologies.github.io/helm-charts/"
-      targetRevision: 1.1.1
+      targetRevision: 1.1.3
       chart: kafka
       valuesFile: "kafka.yaml"

--- a/yggdrasil/services/kafka/kafka/kafka.yaml
+++ b/yggdrasil/services/kafka/kafka/kafka.yaml
@@ -1,19 +1,6 @@
-strimzi-kafka-operator:
-  resources:
-    limits:
-      memory: 1500Mi
-      cpu: 1000m
-    requests:
-      memory: 384Mi
-      cpu: 200m
-  generateNetworkPolicy: false
 cluster:
   kafka:
     replicas: 3
-    offsetTopicReplicationFactor: 3
-    transactionStateLog:
-      replicationFactor: 3
-      minimumInSyncReplicas: 2
     listeners:
     - name: internal
       port: 9092

--- a/yggdrasil/services/kafka/kafka/kafka.yaml
+++ b/yggdrasil/services/kafka/kafka/kafka.yaml
@@ -1,6 +1,9 @@
 cluster:
   kafka:
     replicas: 3
+    config:
+      logRetentionHours: 48
+      logRollHours: 24
     listeners:
     - name: internal
       port: 9092


### PR DESCRIPTION
After the talk a week ago, here is the proposed update to the kafka deployment. 

Set the default log retention to 48 hours and rollover to 24 hours. The effect of this is that logs will be kept from 24 to 48 hours. 